### PR TITLE
Feature: Adds a new parameter to allow deployment of SAM templates larger than 51200 bytes over s3 bucket. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,10 @@ FROM ubuntu
 
 LABEL version="1.0.0"
 
-LABEL com.github.actions.name="(Shared_Studios) SAM Deploy Action"
-LABEL com.github.actions.description="(Shared_Studios) Deploy AWS SAM Stack"
+LABEL com.github.actions.name="SAM Deploy Action"
+LABEL com.github.actions.description="Deploy AWS SAM Stack"
 LABEL com.github.actions.icon="cloud-lightning"
 LABEL com.github.actions.color="orange"
-
-LABEL repository="https://github.com/sharedstudios/sam-deploy-action"
-LABEL homepage="https://github.com/sharedstudios/sam-deploy-action"
-LABEL maintainer="Shared_Studios <software@sharedstudios.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: '(Shared_Studios) SAM Deploy Action'
-description: '(Shared_Studios) Deploy AWS SAM Stack'
+name: 'SAM Deploy Action'
+description: 'Deploy AWS SAM Stack'
 branding:
   icon: 'cloud-lightning'
   color: 'orange'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,10 @@ if [[ $FORCE_UPLOAD == true ]]; then
     FORCE_UPLOAD="--force-upload"
 fi
 
+if [[ $NO_FAIL_EMPTY_CHANGESET == true ]]; then
+    NO_FAIL_EMPTY_CHANGESET="--no-fail-on-empty-changeset"
+fi
+
 if [[ $USE_JSON == true ]]; then
     USE_JSON="--use-json"
 fi
@@ -78,4 +82,4 @@ output = text
 region = $AWS_REGION" > ~/.aws/config
 
 aws cloudformation package --template-file $TEMPLATE --output-template-file serverless-output.yaml --s3-bucket $AWS_DEPLOY_BUCKET $AWS_BUCKET_PREFIX $FORCE_UPLOAD $USE_JSON
-aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME $CAPABILITIES $PARAMETER_OVERRIDES $TAGS
+aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME --s3-bucket $AWS_DEPLOY_BUCKET $CAPABILITIES $PARAMETER_OVERRIDES $TAGS $NO_FAIL_EMPTY_CHANGESET


### PR DESCRIPTION
Feature to deploy a template larger than 51,200 bytes with the command `aws cloudformation deploy`.

`--s3-bucket`: The URI of the Amazon S3 bucket where this command uploads your AWS CloudFormation template. This is required to deploy templates that are larger than 51,200 bytes.

AWS documentation: https://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy/index.html#deploy